### PR TITLE
Fix setup script

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -4,10 +4,6 @@ if ! hash bundle 2>/dev/null; then
   gem install bundler
 fi
 
-if ! hash bower 2>/dev/null; then
-  npm install bower
-fi
-
 (bundle check &>/dev/null) || bundle install
-bower install
 npm install
+$(npm bin)/bower install

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "devDependencies": {
     "babel-eslint": "^4.1.8",
+    "bower": "^1.7.9",
     "eslint": "^1.10.3",
     "eslint-config-airbnb": "^4.0.0"
   }


### PR DESCRIPTION
Why:
- The setup script is assuming that bower will be installed globally in
  the development environment, and does not issue any warning if it is
  not, causing the stylesheets generation to fail due to missing
  dependencies.

This change addresses the issue by:
- Adding `bower` as Node dependency;
- Refactoring the setup script to use the bower installed through NPM.
